### PR TITLE
[Fixes #46] Bug: set additional contact roles in Metadata editor not working

### DIFF
--- a/geonode/base/widgets.py
+++ b/geonode/base/widgets.py
@@ -33,7 +33,7 @@ class TaggitProfileSelect2Custom(TaggitSelect2):
         returns list of selected elements
         """
         try:
-            ret_list = data[name]
+            ret_list = data.getlist(name)
         except KeyError:
             ret_list = []
         finally:


### PR DESCRIPTION
Fixing bug that forbid the setting of new contact roles in geonode

## Description

A brief description of the feature or bug that this pull request addresses.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #46 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request