### PR TITLE
[Fixes #109] Bug: Unable set keywords on geonode_objects when defining keyword via API

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -878,7 +878,11 @@ class ResourceBaseSerializer(
 
     def save(self, **kwargs):
         extent = self.validated_data.pop("extent", None)
+        keywords = self.validated_data.pop("keywords", None)
         instance = super().save(**kwargs)
+        if keywords is not None:
+            instance.keywords.clear()
+            [instance.keywords.add(keyword) for keyword in keywords]
         if extent and instance.get_real_instance()._meta.model in api_bbox_settable_resource_models:
             srid = extent.get("srid", "EPSG:4326")
             coords = extent.get("coords")


### PR DESCRIPTION
## Description
This code changes will allow users to set keywords to datasets, maps and other geonode objects via the API using syntax like e.g.
` geonodectl ds patch 2 --set '{ "keywords": [ {"name" : "test2"}, {"name": "test"}] }'`

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #109 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request