### PR TITLE
[Fixes #109 /2] Bug: Unable set keywords on geonode_objects when defining keyword via API

### DIFF
--- a/geonode/__init__.py
+++ b/geonode/__init__.py
@@ -19,7 +19,7 @@
 
 import os
 
-__version__ = (4, 3, 1, 'final', 0)
+__version__ = (4, 3, 1, "final", 0)
 
 
 def get_version():

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -77,8 +77,6 @@ class KeywordsDynamicRelationField(DynamicRelationField):
 
             django.db.models.QuerySet: return QuerySet object of the request or set data
         """
-
-        related_model = serializer.Meta.model
         try:
             if isinstance(data, str):
                 data = json.loads(data)
@@ -89,6 +87,7 @@ class KeywordsDynamicRelationField(DynamicRelationField):
             return super().to_internal_value_single(data, serializer)
 
         def __set_full_keyword__(d):
+
             if "name" not in d:
                 raise ValidationError('No "name" object found for given keyword ...')
             if "slug" not in d:

--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -161,7 +161,6 @@ class SimpleHierarchicalKeywordSerializer(DynamicModelSerializer):
     def to_representation(self, value):
         return {"name": value.name, "slug": value.slug}
 
-
 class _ThesaurusKeywordSerializerMixIn:
     def to_representation(self, value):
         _i18n = {}
@@ -415,39 +414,6 @@ class FavoriteField(DynamicComputedField):
             return Favorite.objects.filter(object_id=instance.pk, user=_user.user).exists()
         return False
 
-
-# removed with merge to 4.3.1
-# class UserSerializer(BaseDynamicModelSerializer):
-#     class Meta:
-#         ref_name = "UserProfile"
-#         model = get_user_model()
-#         name = "user"
-#         view_name = "users-list"
-#         fields = (
-#             "pk",
-#             "username",
-#             "first_name",
-#             "last_name",
-#             "avatar",
-#             "perms",
-#             "is_superuser",
-#             "is_staff",
-#             "email",
-#             "organization",
-#             "profile",
-#             "position",
-#             "voice",
-#             "fax",
-#             "delivery",
-#             "city",
-#             "area",
-#             "zipcode",
-#             "keywords",
-#             "country",
-#             "language",
-#             "timezone",
-#             "orcid_identifier",
-#         )
 
 class AutoLinkField(DynamicComputedField):
 
@@ -744,7 +710,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
     sourcetype = serializers.CharField(read_only=True)
     embed_url = EmbedUrlField(required=False)
     thumbnail_url = ThumbnailUrlField(read_only=True)
-    keywords = ComplexDynamicRelationField(SimpleHierarchicalKeywordSerializer, many=True)
+    keywords = KeywordsDynamicRelationField(SimpleHierarchicalKeywordSerializer, many=True)
     tkeywords = ComplexDynamicRelationField(SimpleThesaurusKeywordSerializer, many=True)
     regions = DynamicRelationField(SimpleRegionSerializer, embed=True, many=True, read_only=True)
     category = ComplexDynamicRelationField(SimpleTopicCategorySerializer, embed=True)
@@ -884,9 +850,7 @@ class ResourceBaseSerializer(DynamicModelSerializer):
             # metadata_uploaded, metadata_uploaded_preserve, metadata_xml,
             # users_geolimits, groups_geolimits
         )
-
-
-
+ 
     def to_internal_value(self, data):
         if isinstance(data, str):
             data = json.loads(data)
@@ -963,7 +927,6 @@ class HierarchicalKeywordSerializer(BaseResourceCountSerializer):
         count_type = "keywords"
         view_name = "keywords-list"
         fields = "__all__"
-
 
 class ThesaurusKeywordSerializer(_ThesaurusKeywordSerializerMixIn, BaseResourceCountSerializer):
     class Meta:

--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -278,7 +278,6 @@ class HierarchicalKeywordManager(MP_NodeManager):
     def get_queryset(self):
         return HierarchicalKeywordQuerySet(self.model).order_by("path")
 
-
 class HierarchicalKeyword(TagBase, MP_Node):
     node_order_by = ["name"]
     objects = HierarchicalKeywordManager()

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -1486,7 +1486,11 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
         # Set download links for WMS, WCS or WFS and KML
         logger.debug(" -- Resource Links[Set download links for WMS, WCS or WFS and KML]...")
         instance_ows_url = f"{instance.ows_url}?" if instance.ows_url else f"{ogc_server_settings.public_url}ows?"
-        links = wms_links(instance_ows_url, instance.alternate, bbox, srid, height, width) if instance.subtype != "tabular" else []
+        links = (
+            wms_links(instance_ows_url, instance.alternate, bbox, srid, height, width)
+            if instance.subtype != "tabular"
+            else []
+        )
 
         for ext, name, mime, wms_url in links:
             try:
@@ -1650,8 +1654,10 @@ def set_resource_default_links(instance, layer, prune=False, **kwargs):
                 ogc_wms_url = instance.ows_url or urljoin(ogc_server_settings.public_url, "ows")
                 ogc_wms_name = f"OGC WMS: {instance.workspace} Service"
                 if (
-                    instance.subtype != "tabular" and
-                    Link.objects.filter(resource=instance.resourcebase_ptr, name=ogc_wms_name, url=ogc_wms_url).count()
+                    instance.subtype != "tabular"
+                    and Link.objects.filter(
+                        resource=instance.resourcebase_ptr, name=ogc_wms_name, url=ogc_wms_url
+                    ).count()
                     < 2
                 ):
                     Link.objects.get_or_create(


### PR DESCRIPTION
## Description
Basically only enabled the previously implemented `KeywordsDynamicRelationField` Field Class.

additionally runned black, which affected tabular changes, and I removed artifacts from merge of 4.3.1

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #109 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request