### PR TITLE
Issue #378 bug  group profile serializer requires 'group' field on post but it should be auto created from slug

### DIFF
--- a/geonode/base/api/serializers.py
+++ b/geonode/base/api/serializers.py
@@ -150,7 +150,7 @@ class GroupProfileSerializer(BaseDynamicModelSerializer):
         view_name = "group-profiles-list"
         fields = ("pk", "title", "group", "slug", "logo", "description", "email", "keywords", "access", "categories")
 
-    group = DynamicRelationField(GroupSerializer, embed=True, many=False, required=False, read_only=False)
+    group = DynamicRelationField(GroupSerializer, embed=True, many=False, read_only=True)
     keywords = serializers.SlugRelatedField(many=True, slug_field="slug", read_only=True)
     categories = serializers.SlugRelatedField(
         many=True, slug_field="slug", queryset=GroupCategory.objects.all(), required=False


### PR DESCRIPTION
## Description
Fixing geonode v2/api/groups endpoint along to work with https://github.com/GeoNodeUserGroup-DE/geonodectl/pull/118

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #378

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request