### PR TITLE
.Funding relation upsert generic for nested payloads

### DIFF
--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -130,10 +130,6 @@ class FundingsDynamicRelationField(DynamicRelationField):
         for keys in rel_cfg.get("lookup_order", ()):
             if all(rel_data.get(k) not in (None, "") for k in keys):
                 lookup = {k: rel_data[k] for k in keys}
-                instance = model.objects.filter(**lookup).first()
-                if instance:
-                    return instance
-
                 defaults = {k: v for k, v in rel_data.items() if k not in lookup}
                 try:
                     return model.objects.get_or_create(**lookup, defaults=defaults)[0]

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -57,16 +57,117 @@ class RelatedIdentifierDynamicRelationField(DynamicRelationField):
 
 
 class FundingsDynamicRelationField(DynamicRelationField):
+    """Generic nested get-or-create handler for fundings payload.
+
+    Supports payloads with either:
+    - organization: {...}
+    - funding_organization: {...}
+
+    and resolves/creates Organization first, then Funding.
+    """
+
+    nested_relations = {
+        "organization": {
+            "model": Organization,
+            "aliases": ("organization", "funding_organization"),
+            # Prefer stable identifiers first, then progressively weaker matches.
+            "lookup_order": (("ror",), ("organization", "abbreviation"), ("organization",)),
+            "required": True,
+        }
+    }
+
+    @staticmethod
+    def _clean_dict(data):
+        return {k: v for k, v in data.items() if v not in (None, "")}
+
+    def _get_alias_value(self, data, aliases):
+        for alias in aliases:
+            if alias in data:
+                return alias, data[alias]
+        return None, None
+
+    def _resolve_nested_instance(self, rel_name, rel_cfg, rel_raw):
+        model = rel_cfg["model"]
+
+        if isinstance(rel_raw, model):
+            return rel_raw
+
+        if isinstance(rel_raw, int):
+            return model.objects.get(pk=rel_raw)
+
+        if not isinstance(rel_raw, dict):
+            raise ParseError(
+                detail=f"Invalid object for '{rel_name}' in payload ...",
+                code=400,
+            )
+
+        rel_data = dict(rel_raw)
+
+        # Allow direct reference by id when clients already have it.
+        if rel_data.get("id"):
+            return model.objects.get(pk=rel_data["id"])
+
+        rel_data = self._clean_dict(rel_data)
+        if not rel_data:
+            raise ParseError(
+                detail=f"Missing '{rel_name}' object in payload ...",
+                code=400,
+            )
+
+        # Try deterministic lookup chains first; create only if no match exists.
+        for keys in rel_cfg.get("lookup_order", ()):
+            if all(rel_data.get(k) not in (None, "") for k in keys):
+                lookup = {k: rel_data[k] for k in keys}
+                instance = model.objects.filter(**lookup).first()
+                if instance:
+                    return instance
+
+                defaults = {k: v for k, v in rel_data.items() if k not in lookup}
+                return model.objects.get_or_create(**lookup, defaults=defaults)[0]
+
+        return model.objects.get_or_create(**rel_data)[0]
+
     def to_internal_value_single(self, data, serializer):
         try:
-            organization = Organization.objects.get(**data["organization"])
-            data["organization"] = organization
-        except TypeError:
-            raise ParseError(detail="Missing funding_organization object in funding ...", code=400)
+            if isinstance(data, str):
+                data = json.loads(data)
+        except ValueError:
+            return super().to_internal_value_single(data, serializer)
+
+        if not isinstance(data, dict):
+            return super().to_internal_value_single(data, serializer)
+
+        payload = dict(data)
+
+        # Reuse existing funding if id is explicitly provided.
+        funding_id = payload.get("id")
+        if funding_id:
+            return Funding.objects.get(pk=funding_id)
+
         try:
-            funder = Funding.objects.get_or_create(**data)
+            for rel_name, rel_cfg in self.nested_relations.items():
+                alias, rel_raw = self._get_alias_value(payload, rel_cfg.get("aliases", (rel_name,)))
+                if rel_raw is None:
+                    if rel_cfg.get("required", False):
+                        raise ParseError(
+                            detail=f"Missing {rel_name} object in funding ...",
+                            code=400,
+                        )
+                    continue
+
+                payload[rel_name] = self._resolve_nested_instance(rel_name, rel_cfg, rel_raw)
+
+                # Remove alias key if canonical key differs.
+                if alias and alias != rel_name:
+                    payload.pop(alias, None)
+
+            payload = self._clean_dict(payload)
+            funder = Funding.objects.get_or_create(**payload)
         except TypeError:
             raise ParseError(detail="Could not convert funding to internal object ...", code=400)
+        except ValidationError:
+            raise ParseError(detail="Invalid funding payload ...", code=400)
+
         return funder[0]
 
 

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -18,7 +18,7 @@
 #########################################################################
 import json
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, MultipleObjectsReturned
 
 from rest_framework.exceptions import ParseError
 from dynamic_rest.fields.fields import DynamicRelationField
@@ -92,9 +92,15 @@ class FundingsDynamicRelationField(DynamicRelationField):
         if isinstance(rel_raw, model):
             return rel_raw
 
-        if isinstance(rel_raw, int):
+        if isinstance(rel_raw, (int, str)):
+            rel_raw_id = rel_raw
+            if isinstance(rel_raw, str):
+                rel_raw_id = rel_raw.strip()
+                if not rel_raw_id.isdigit():
+                    rel_raw_id = None
             try:
-                return model.objects.get(pk=rel_raw)
+                if rel_raw_id is not None:
+                    return model.objects.get(pk=int(rel_raw_id))
             except model.DoesNotExist:
                 raise ParseError(detail=f"Object with id={rel_raw} for '{rel_name}' not found", code=400)
 
@@ -131,10 +137,14 @@ class FundingsDynamicRelationField(DynamicRelationField):
                 defaults = {k: v for k, v in rel_data.items() if k not in lookup}
                 return model.objects.get_or_create(**lookup, defaults=defaults)[0]
 
-        instance = model.objects.filter(**rel_data).first()
-        if instance:
+        try:
+            instance, _ = model.objects.get_or_create(**rel_data)
             return instance
-        return model.objects.create(**rel_data)
+        except MultipleObjectsReturned:
+            instance = model.objects.filter(**rel_data).first()
+            if instance:
+                return instance
+            raise
 
     def to_internal_value_single(self, data, serializer):
         try:
@@ -174,9 +184,12 @@ class FundingsDynamicRelationField(DynamicRelationField):
                     payload.pop(alias, None)
 
             payload = self._clean_dict(payload)
-            funder = Funding.objects.filter(**payload).first()
-            if not funder:
-                funder = Funding.objects.create(**payload)
+            try:
+                funder, _ = Funding.objects.get_or_create(**payload)
+            except MultipleObjectsReturned:
+                funder = Funding.objects.filter(**payload).first()
+                if not funder:
+                    raise
         except TypeError:
             raise ParseError(detail="Could not convert funding to internal object ...", code=400)
         except ValidationError:

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -135,16 +135,16 @@ class FundingsDynamicRelationField(DynamicRelationField):
                     return instance
 
                 defaults = {k: v for k, v in rel_data.items() if k not in lookup}
-                return model.objects.get_or_create(**lookup, defaults=defaults)[0]
+                try:
+                    return model.objects.get_or_create(**lookup, defaults=defaults)[0]
+                except MultipleObjectsReturned:
+                    return model.objects.filter(**lookup).first()
 
         try:
             instance, _ = model.objects.get_or_create(**rel_data)
             return instance
         except MultipleObjectsReturned:
-            instance = model.objects.filter(**rel_data).first()
-            if instance:
-                return instance
-            raise
+            return model.objects.filter(**rel_data).first()
 
     def to_internal_value_single(self, data, serializer):
         try:
@@ -188,8 +188,6 @@ class FundingsDynamicRelationField(DynamicRelationField):
                 funder, _ = Funding.objects.get_or_create(**payload)
             except MultipleObjectsReturned:
                 funder = Funding.objects.filter(**payload).first()
-                if not funder:
-                    raise
         except TypeError:
             raise ParseError(detail="Could not convert funding to internal object ...", code=400)
         except ValidationError:

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -134,13 +134,13 @@ class FundingsDynamicRelationField(DynamicRelationField):
                 try:
                     return model.objects.get_or_create(**lookup, defaults=defaults)[0]
                 except MultipleObjectsReturned:
-                    return model.objects.filter(**lookup).first()
+                    return model.objects.filter(**lookup).order_by("pk").first()
 
         try:
             instance, _ = model.objects.get_or_create(**rel_data)
             return instance
         except MultipleObjectsReturned:
-            return model.objects.filter(**rel_data).first()
+            return model.objects.filter(**rel_data).order_by("pk").first()
 
     def to_internal_value_single(self, data, serializer):
         try:
@@ -157,6 +157,13 @@ class FundingsDynamicRelationField(DynamicRelationField):
         # Reuse existing funding if id is explicitly provided.
         funding_id = payload.get("id")
         if funding_id:
+            extra_fields = {k: v for k, v in payload.items() if k != "id" and v not in (None, "")}
+            if extra_fields:
+                raise ParseError(
+                    detail="Funding payload with 'id' cannot include update fields. "
+                    "Use either an id reference or a full nested object without id.",
+                    code=400,
+                )
             try:
                 return Funding.objects.get(pk=funding_id)
             except (ValueError, TypeError, Funding.DoesNotExist):
@@ -183,7 +190,7 @@ class FundingsDynamicRelationField(DynamicRelationField):
             try:
                 funder, _ = Funding.objects.get_or_create(**payload)
             except MultipleObjectsReturned:
-                funder = Funding.objects.filter(**payload).first()
+                funder = Funding.objects.filter(**payload).order_by("pk").first()
         except TypeError:
             raise ParseError(detail="Could not convert funding to internal object ...", code=400)
         except ValidationError:

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -116,7 +116,7 @@ class FundingsDynamicRelationField(DynamicRelationField):
         if rel_data.get("id"):
             try:
                 return model.objects.get(pk=rel_data["id"])
-            except model.DoesNotExist:
+            except (ValueError, TypeError, model.DoesNotExist):
                 raise ParseError(detail=f"Object with id={rel_data['id']} for '{rel_name}' not found", code=400)
 
         rel_data = self._clean_dict(rel_data)
@@ -163,7 +163,7 @@ class FundingsDynamicRelationField(DynamicRelationField):
         if funding_id:
             try:
                 return Funding.objects.get(pk=funding_id)
-            except Funding.DoesNotExist:
+            except (ValueError, TypeError, Funding.DoesNotExist):
                 raise ParseError(detail=f"Funding with id={funding_id} not found", code=400)
 
         try:

--- a/geonode/base/api/fields.py
+++ b/geonode/base/api/fields.py
@@ -93,7 +93,10 @@ class FundingsDynamicRelationField(DynamicRelationField):
             return rel_raw
 
         if isinstance(rel_raw, int):
-            return model.objects.get(pk=rel_raw)
+            try:
+                return model.objects.get(pk=rel_raw)
+            except model.DoesNotExist:
+                raise ParseError(detail=f"Object with id={rel_raw} for '{rel_name}' not found", code=400)
 
         if not isinstance(rel_raw, dict):
             raise ParseError(
@@ -105,7 +108,10 @@ class FundingsDynamicRelationField(DynamicRelationField):
 
         # Allow direct reference by id when clients already have it.
         if rel_data.get("id"):
-            return model.objects.get(pk=rel_data["id"])
+            try:
+                return model.objects.get(pk=rel_data["id"])
+            except model.DoesNotExist:
+                raise ParseError(detail=f"Object with id={rel_data['id']} for '{rel_name}' not found", code=400)
 
         rel_data = self._clean_dict(rel_data)
         if not rel_data:
@@ -125,7 +131,10 @@ class FundingsDynamicRelationField(DynamicRelationField):
                 defaults = {k: v for k, v in rel_data.items() if k not in lookup}
                 return model.objects.get_or_create(**lookup, defaults=defaults)[0]
 
-        return model.objects.get_or_create(**rel_data)[0]
+        instance = model.objects.filter(**rel_data).first()
+        if instance:
+            return instance
+        return model.objects.create(**rel_data)
 
     def to_internal_value_single(self, data, serializer):
         try:
@@ -142,7 +151,10 @@ class FundingsDynamicRelationField(DynamicRelationField):
         # Reuse existing funding if id is explicitly provided.
         funding_id = payload.get("id")
         if funding_id:
-            return Funding.objects.get(pk=funding_id)
+            try:
+                return Funding.objects.get(pk=funding_id)
+            except Funding.DoesNotExist:
+                raise ParseError(detail=f"Funding with id={funding_id} not found", code=400)
 
         try:
             for rel_name, rel_cfg in self.nested_relations.items():
@@ -162,13 +174,15 @@ class FundingsDynamicRelationField(DynamicRelationField):
                     payload.pop(alias, None)
 
             payload = self._clean_dict(payload)
-            funder = Funding.objects.get_or_create(**payload)
+            funder = Funding.objects.filter(**payload).first()
+            if not funder:
+                funder = Funding.objects.create(**payload)
         except TypeError:
             raise ParseError(detail="Could not convert funding to internal object ...", code=400)
         except ValidationError:
             raise ParseError(detail="Invalid funding payload ...", code=400)
 
-        return funder[0]
+        return funder
 
 
 class KeywordsDynamicRelationField(DynamicRelationField):

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -73,7 +73,10 @@ from geonode.base.models import (
     RelatedIdentifierType,
     RelationType,
     ResourceTypeGeneral,
+    Organization,
+    Funding,
 )
+from geonode.base.api.fields import FundingsDynamicRelationField
 from geonode.base.middleware import ReadOnlyMiddleware, MaintenanceMiddleware
 from geonode.base.templatetags.base_tags import get_visibile_resources, facets
 from geonode.base.templatetags.thesaurus import (
@@ -218,6 +221,68 @@ class TestCreationOfContactRolesByDifferentInputTypes(ThumbnailTests):
         self.rb.owner = user
         self.rb.metadata_author = profile_list
         self.rb.poc = profile_list
+
+
+class FundingsDynamicRelationFieldTests(TestCase):
+    def setUp(self):
+        self.field = FundingsDynamicRelationField(None)
+
+    def test_creates_funding_and_organization_from_payload(self):
+        payload = {
+            "organization": {
+                "organization": "European Commission",
+                "ror": "https://ror.org/998nnx307",
+                "abbreviation": "EC",
+            },
+            "award_title": "Research on Agricultural Innovation",
+            "award_number": "H2020-123456",
+            "award_uri": "https://cordis.europa.eu/project/id/123456",
+        }
+
+        funding = self.field.to_internal_value_single(payload, serializer=None)
+
+        self.assertIsInstance(funding, Funding)
+        self.assertEqual(funding.organization.ror, "https://ror.org/998nnx307")
+        self.assertEqual(Organization.objects.filter(ror="https://ror.org/998nnx307").count(), 1)
+
+    def test_supports_funding_organization_alias(self):
+        payload = {
+            "funding_organization": {
+                "organization": "German Federal Ministry of Education and Research (BMBF)",
+                "ror": "https://ror.org/04wxnsj81",
+                "abbreviation": "BMBF",
+            },
+            "award_title": "ZALF Research Initiative",
+            "award_number": "01LC1234",
+            "award_uri": "https://www.bmbf.de",
+        }
+
+        funding = self.field.to_internal_value_single(payload, serializer=None)
+
+        self.assertEqual(funding.organization.ror, "https://ror.org/04wxnsj81")
+        self.assertEqual(Organization.objects.filter(ror="https://ror.org/04wxnsj81").count(), 1)
+
+    def test_reuses_existing_organization_by_ror(self):
+        org = Organization.objects.create(
+            organization="National Science Foundation",
+            ror="https://ror.org/01sjfss47",
+            abbreviation="NSF",
+        )
+        payload = {
+            "organization": {
+                "organization": "National Science Foundation (duplicate name variation)",
+                "ror": "https://ror.org/01sjfss47",
+                "abbreviation": "NSF",
+            },
+            "award_title": "Data Integration for Environmental Science",
+            "award_number": "NSF-2024-5678",
+            "award_uri": "https://nsf.gov/awardsearch/showAward",
+        }
+
+        funding = self.field.to_internal_value_single(payload, serializer=None)
+
+        self.assertEqual(funding.organization.pk, org.pk)
+        self.assertEqual(Organization.objects.filter(ror="https://ror.org/01sjfss47").count(), 1)
         self.rb.publisher = profile_list
         self.rb.custodian = profile_list
         self.rb.distributor = profile_list

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -351,6 +351,38 @@ class FundingsDynamicRelationFieldTests(TestCase):
         with self.assertRaises(ParseError):
             self.field.to_internal_value_single(payload, serializer=None)
 
+    def test_resolves_nested_organization_id_sent_as_string(self):
+        org = Organization.objects.create(
+            organization="European Commission",
+            ror="https://ror.org/998nnx307",
+            abbreviation="EC",
+        )
+        payload = {
+            "organization": str(org.pk),
+            "award_title": "Research on Agricultural Innovation",
+            "award_number": "H2020-123456",
+            "award_uri": "https://cordis.europa.eu/project/id/123456",
+        }
+
+        funding = self.field.to_internal_value_single(payload, serializer=None)
+        self.assertEqual(funding.organization.pk, org.pk)
+
+    def test_resolves_funding_id_sent_as_string(self):
+        org = Organization.objects.create(
+            organization="NSF",
+            ror="https://ror.org/01sjfss47",
+            abbreviation="NSF",
+        )
+        funding = Funding.objects.create(
+            organization=org,
+            award_title="Data Integration",
+            award_number="NSF-2024-5678",
+            award_uri="https://nsf.gov/awardsearch/showAward",
+        )
+
+        resolved = self.field.to_internal_value_single({"id": str(funding.pk)}, serializer=None)
+        self.assertEqual(resolved.pk, funding.pk)
+
 
 class RenderMenuTagTest(GeoNodeBaseTestSupport):
     """

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -383,6 +383,20 @@ class FundingsDynamicRelationFieldTests(TestCase):
         resolved = self.field.to_internal_value_single({"id": str(funding.pk)}, serializer=None)
         self.assertEqual(resolved.pk, funding.pk)
 
+    def test_raises_parse_error_for_non_numeric_funding_id_string(self):
+        with self.assertRaises(ParseError):
+            self.field.to_internal_value_single({"id": "abc"}, serializer=None)
+
+    def test_raises_parse_error_for_non_numeric_nested_organization_id_string(self):
+        payload = {
+            "organization": {"id": "abc"},
+            "award_title": "Any",
+            "award_number": "X-1",
+            "award_uri": "https://example.org/award",
+        }
+        with self.assertRaises(ParseError):
+            self.field.to_internal_value_single(payload, serializer=None)
+
 
 class RenderMenuTagTest(GeoNodeBaseTestSupport):
     """

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -37,6 +37,7 @@ from django.contrib.auth import get_user_model
 from geonode.storage.manager import storage_manager
 from django.test import Client, TestCase, override_settings, SimpleTestCase
 from rest_framework.test import APITestCase
+from rest_framework.exceptions import ParseError
 from django.shortcuts import reverse
 from django.utils import translation
 from django.core.files import File
@@ -221,6 +222,58 @@ class TestCreationOfContactRolesByDifferentInputTypes(ThumbnailTests):
         self.rb.owner = user
         self.rb.metadata_author = profile_list
         self.rb.poc = profile_list
+        self.rb.publisher = profile_list
+        self.rb.custodian = profile_list
+        self.rb.distributor = profile_list
+        self.rb.resource_user = profile_list
+        self.rb.resource_provider = profile_list
+        self.rb.originator = profile_list
+        self.rb.principal_investigator = profile_list
+        self.rb.processor = profile_list
+
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.metadata_author])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.poc])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.publisher])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.custodian])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.distributor])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_user])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_provider])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.originator])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.principal_investigator])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.processor])
+
+    """
+    Test that contact roles can be set as queryset
+    """
+
+    def test_set_contact_role_as_queryset(self):
+        user, _ = get_user_model().objects.get_or_create(username="zlatan_i")
+        user2, _ = get_user_model().objects.get_or_create(username="sven_z")
+
+        query = get_user_model().objects.filter(username__in=["zlatan_i", "sven_z"])
+
+        self.rb.owner = user
+        self.rb.metadata_author = query
+        self.rb.poc = query
+        self.rb.publisher = query
+        self.rb.custodian = query
+        self.rb.distributor = query
+        self.rb.resource_user = query
+        self.rb.resource_provider = query
+        self.rb.originator = query
+        self.rb.principal_investigator = query
+        self.rb.processor = query
+
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.metadata_author])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.poc])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.publisher])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.custodian])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.distributor])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_user])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_provider])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.originator])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.principal_investigator])
+        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.processor])
 
 
 class FundingsDynamicRelationFieldTests(TestCase):
@@ -283,58 +336,20 @@ class FundingsDynamicRelationFieldTests(TestCase):
 
         self.assertEqual(funding.organization.pk, org.pk)
         self.assertEqual(Organization.objects.filter(ror="https://ror.org/01sjfss47").count(), 1)
-        self.rb.publisher = profile_list
-        self.rb.custodian = profile_list
-        self.rb.distributor = profile_list
-        self.rb.resource_user = profile_list
-        self.rb.resource_provider = profile_list
-        self.rb.originator = profile_list
-        self.rb.principal_investigator = profile_list
-        self.rb.processor = profile_list
 
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.metadata_author])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.poc])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.publisher])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.custodian])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.distributor])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_user])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_provider])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.originator])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.principal_investigator])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.processor])
+    def test_raises_parse_error_for_invalid_funding_id(self):
+        with self.assertRaises(ParseError):
+            self.field.to_internal_value_single({"id": 999999}, serializer=None)
 
-    """
-    Test that contact roles can be set as queryset
-    """
-
-    def test_set_contact_role_as_queryset(self):
-        user, _ = get_user_model().objects.get_or_create(username="zlatan_i")
-        user2, _ = get_user_model().objects.get_or_create(username="sven_z")
-
-        query = get_user_model().objects.filter(username__in=["zlatan_i", "sven_z"])
-
-        self.rb.owner = user
-        self.rb.metadata_author = query
-        self.rb.poc = query
-        self.rb.publisher = query
-        self.rb.custodian = query
-        self.rb.distributor = query
-        self.rb.resource_user = query
-        self.rb.resource_provider = query
-        self.rb.originator = query
-        self.rb.principal_investigator = query
-        self.rb.processor = query
-
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.metadata_author])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.poc])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.publisher])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.custodian])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.distributor])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_user])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.resource_provider])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.originator])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.principal_investigator])
-        self.assertTrue("zlatan_i" and "sven_z" in [cr.username for cr in self.rb.processor])
+    def test_raises_parse_error_for_invalid_nested_organization_id(self):
+        payload = {
+            "organization": {"id": 999999},
+            "award_title": "Any",
+            "award_number": "X-1",
+            "award_uri": "https://example.org/award",
+        }
+        with self.assertRaises(ParseError):
+            self.field.to_internal_value_single(payload, serializer=None)
 
 
 class RenderMenuTagTest(GeoNodeBaseTestSupport):

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -387,6 +387,24 @@ class FundingsDynamicRelationFieldTests(TestCase):
         with self.assertRaises(ParseError):
             self.field.to_internal_value_single({"id": "abc"}, serializer=None)
 
+    def test_raises_parse_error_for_id_plus_update_fields(self):
+        org = Organization.objects.create(
+            organization="NSF",
+            ror="https://ror.org/01sjfss47",
+            abbreviation="NSF",
+        )
+        funding = Funding.objects.create(
+            organization=org,
+            award_title="Data Integration",
+            award_number="NSF-2024-5678",
+            award_uri="https://nsf.gov/awardsearch/showAward",
+        )
+        with self.assertRaises(ParseError):
+            self.field.to_internal_value_single(
+                {"id": funding.pk, "award_title": "Attempted inline update"},
+                serializer=None,
+            )
+
     def test_raises_parse_error_for_non_numeric_nested_organization_id_string(self):
         payload = {
             "organization": {"id": "abc"},


### PR DESCRIPTION
.Generic Parsing for Fundings and Test
I had problems when I was trying to upload the metadata of Fundings to GeoNode
These helpers are available in cases where they reference existing funding objects (with ID) because Inline creation may fail with code 500.