### PR TITLE
[Fixes #571]: "Bug: Free text fields with and without content are not visible in the metadata editor in geonode after GN update from 08.08.2026"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ django-guardian<2.4.1
 django-downloadview==2.3.0
 django-polymorphic==3.1.0
 django-tastypie<0.15.0
-django-tinymce==4.1.0
+django-tinymce==3.7.1
 django-grappelli==4.0.1
 django-uuid-upload-path==1.0.0
 django-widget-tweaks==1.5.0


### PR DESCRIPTION
## Description

downgrade django-tinymce will be removed with geonode 5.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #571 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request